### PR TITLE
Fix spoiler blocking for VOD titles and lengths

### DIFF
--- a/src/content/content.css
+++ b/src/content/content.css
@@ -12,9 +12,11 @@
   display: none !important;
 }
 
-/* Hide text while maintaining layout */
+/* Style spoiler-hidden text to make it clear it's a spoiler warning */
 .spoiler-hidden-text {
-  visibility: hidden !important;
+  color: #9147ff !important; /* Twitch purple */
+  font-style: italic !important;
+  opacity: 0.8 !important;
 }
 
 /* Prevent hover previews from playing */

--- a/src/content/selectors.js
+++ b/src/content/selectors.js
@@ -15,6 +15,8 @@ const THUMBNAIL_SELECTORS = [
 ];
 
 const VOD_LENGTH_SELECTORS = [
+  '.tw-media-card-stat',
+  '[class*="MediaCardStat"]',
   '[data-a-target="video-time"]',
   '[class*="video-length"]',
   '[class*="duration-overlay"]',
@@ -26,7 +28,10 @@ const VOD_LENGTH_SELECTORS = [
 ];
 
 const TITLE_SELECTORS = [
+  '[data-a-target="stream-title"]',
   '[data-a-target="video-title"]',
+  'a[href^="/videos/"] h4',
+  '.online-side-nav-channel-tooltip__body p',
   'h3[class*="tw-title"]',
   'h3[class*="video-card"]',
   '.video-card-title',

--- a/src/content/spoiler-blocker.js
+++ b/src/content/spoiler-blocker.js
@@ -102,10 +102,19 @@ class TwitchSpoilerBlocker {
 
     elements.forEach(el => {
       if (!this.appliedElements.has(el)) {
-        el.classList.add('spoiler-hidden-element');
-        this.appliedElements.add(el);
+        // Only hide if it looks like a duration (MM:SS or HH:MM:SS format)
+        const text = el.textContent.trim();
+        if (this.isDuration(text)) {
+          el.classList.add('spoiler-hidden-element');
+          this.appliedElements.add(el);
+        }
       }
     });
+  }
+
+  isDuration(text) {
+    // Match patterns like 1:23, 12:34, 1:23:45, or 12:34:56
+    return /^\d{1,2}:\d{2}(:\d{2})?$/.test(text);
   }
 
   hideTitles() {
@@ -115,6 +124,12 @@ class TwitchSpoilerBlocker {
 
     elements.forEach(el => {
       if (!this.appliedElements.has(el)) {
+        // Store original text if not already stored
+        if (!el.dataset.originalText) {
+          el.dataset.originalText = el.textContent;
+        }
+        // Replace with spoiler warning
+        el.textContent = '[SPOILER HIDDEN]';
         el.classList.add('spoiler-hidden-text');
         this.appliedElements.add(el);
       }
@@ -151,7 +166,11 @@ class TwitchSpoilerBlocker {
   checkAndHideVodLength(element) {
     for (const selector of window.VOD_LENGTH_SELECTORS) {
       if (element.matches(selector)) {
-        element.classList.add('spoiler-hidden-element');
+        // Only hide if it looks like a duration
+        const text = element.textContent.trim();
+        if (this.isDuration(text)) {
+          element.classList.add('spoiler-hidden-element');
+        }
         return;
       }
     }
@@ -160,6 +179,12 @@ class TwitchSpoilerBlocker {
   checkAndHideTitle(element) {
     for (const selector of window.TITLE_SELECTORS) {
       if (element.matches(selector)) {
+        // Store original text if not already stored
+        if (!element.dataset.originalText) {
+          element.dataset.originalText = element.textContent;
+        }
+        // Replace with spoiler warning
+        element.textContent = '[SPOILER HIDDEN]';
         element.classList.add('spoiler-hidden-text');
         return;
       }
@@ -204,8 +229,12 @@ class TwitchSpoilerBlocker {
       el.classList.remove('spoiler-hidden-element');
     });
 
-    // Remove text hiding
+    // Remove text hiding and restore original text
     document.querySelectorAll('.spoiler-hidden-text').forEach(el => {
+      if (el.dataset.originalText) {
+        el.textContent = el.dataset.originalText;
+        delete el.dataset.originalText;
+      }
       el.classList.remove('spoiler-hidden-text');
     });
 


### PR DESCRIPTION
- Updated selectors to match actual Twitch HTML structure including:
  - [data-a-target="stream-title"] for VOD page titles  - a[href^="/videos/"] h4 for VOD menu titles
  - .online-side-nav-channel-tooltip__body p for hover tooltips
  - .tw-media-card-stat for VOD lengths

- Changed title hiding to replace text with '[SPOILER HIDDEN]' instead of visibility:hidden
  - More user-friendly and clear about why text is hidden
  - Stores original text in data attribute for easy restoration

- Made VOD length hiding smarter by checking if text matches duration format (MM:SS or HH:MM:SS)  - Prevents hiding view counts and timestamps that use same CSS classes

- Updated CSS to style spoiler text with Twitch purple color and italics